### PR TITLE
Fix debug artifacts not being collected on test timeout

### DIFF
--- a/workflow-templates/vsphere-integration.yaml
+++ b/workflow-templates/vsphere-integration.yaml
@@ -5,7 +5,7 @@ jobs:
   integration-test:
     name: VSphere Integration Test
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -23,6 +23,7 @@ jobs:
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run test
         run: tox -e integration
+        timeout-minutes: 60
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp


### PR DESCRIPTION
In https://github.com/charmed-kubernetes/charm-kube-ovn/runs/7048925101?check_suite_focus=true the job timed out after 1 hour and no debug artifacts were collected. I need that crashdump to figure out why it got stuck.

My proposed fix here is to put a 1 hour timeout on the `tox -e integration` step, and bump the job's total timeout to 2 hours so that it has plenty of time to collect debug artifacts.