### PR TITLE
Remove timeout from `tox -e integration` step

### DIFF
--- a/workflow-templates/vsphere-integration.yaml
+++ b/workflow-templates/vsphere-integration.yaml
@@ -23,7 +23,6 @@ jobs:
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run test
         run: tox -e integration
-        timeout-minutes: 60
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp


### PR DESCRIPTION
In https://github.com/charmed-kubernetes/charm-kube-ovn/pull/13 I saw that having a timeout on `tox -e integration` prevents pytest-operator from cleaning up models and collecting crashdumps properly.